### PR TITLE
Add ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.3
 ENV VAULT_VERSION 0.5.2
 
 ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip vault.zip
-RUN apk add --update unzip openssl && \
+RUN apk add --update unzip openssl ca-certificates && \
     unzip vault.zip && \
     rm vault.zip && \
     cp vault /usr/bin && \


### PR DESCRIPTION
Without the `ca-certificates` package, any vault endpoint (such as the github auth mountpoint) that makes a `https` request will fail with `x509: failed to load system roots and no roots provided`.
